### PR TITLE
Fix port error, add debugging function, change RM command to rimraf compatible with different systems

### DIFF
--- a/generators/ app/ templates/ public/ docs/swagger.json
+++ b/generators/ app/ templates/ public/ docs/swagger.json
@@ -3,7 +3,7 @@
 	"servers": [
 		{
 			"description": "local api",
-			"url": "http://localhost:3001/api/v1/"
+			"url": "http://localhost:3000/api/v1/"
 		}
 	],
 	"info": {

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -4,19 +4,19 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "clean": "rm -rf .build/*",
-    "clean:installDependencies": "rm -rf ./node_modules",
+    "clean": "rimraf -rf .build/*",
+    "clean:installDependencies": "rimraf -rf ./node_modules",
     "build:dev": "babel src -s -D -d .build",
     "start:dev": "npm run clean && npm run build:dev",
     "lint": "./node_modules/.bin/eslint src/**",
     "lint:test": "./node_modules/.bin/eslint test/**",
     "lint:fix": "./node_modules/.bin/eslint src/** --fix",
     "lint:test:fix": "./node_modules/.bin/eslint test/** --fix",
-    "start": "npm run start:dev && node ./.build/server.js",
+    "start": "npm run start:dev && node debug ./.build/server.js",
     "docker:clean": "npm run clean:installDependencies",
     "test": "npm run test:coverage:clean && cross-env NODE_ENV=test nyc --reporter=html --reporter=text ./node_modules/mocha/bin/mocha --require @babel/register test/**",
     "test:coverage": "nyc report --reporter=text-lcov | coveralls",
-    "test:coverage:clean": "rm -rf coverage/*"
+    "test:coverage:clean": "rimraf -rf coverage/*"
   },
   "standard": {
     "parser": "babel-eslint"
@@ -53,7 +53,8 @@
     "nyc": "^10.3.2",
     "sinon": "^7.3.2",
     "standard": "^8.4.0",
-    "supertest": "^4.0.2"
+    "supertest": "^4.0.2",
+    "rimraf": "^2.6.3"
   },
   "dependencies": {
     "bcrypt": "^3.0.6",


### PR DESCRIPTION
Fix port error, add debugging function, change RM command to rimraf compatible with different systems
---
修复端口错误、新增调试功能、将rm命令改成rimraf兼容不同系统


1.'rm' 不是内部或外部命令，也不是可运行的程序
或批处理文件。
2.Provisional headers are shown
3.不能调试